### PR TITLE
Update pod statement in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ CLLocationManager-block is available through [CocoaPods](http://cocoapods.org), 
 it simply add the following line to your Podfile:
 
 ```
-pod "CLLocationManager-block"
+pod 'CLLocationManager-blocks'
 ```
 
 ##Usage


### PR DESCRIPTION
Add the trailing 's' to the pod statement in the README and switch to single quotes to match the style used on the CocoaPods site.
